### PR TITLE
Initial attempt at writing DateTime to ISO 8601

### DIFF
--- a/app/controllers/Se4Controller.scala
+++ b/app/controllers/Se4Controller.scala
@@ -1,5 +1,6 @@
 package controllers
 
+import org.joda.time.format.{ISODateTimeFormat, DateTimeFormat}
 import org.joda.time.{ DateTime, DateTimeZone, Duration => JodaDuration }
 import play.api.libs.json.{ Format, JsResult, JsValue, Json }
 import play.api.mvc.{ Action, AnyContent, Controller }
@@ -113,7 +114,13 @@ final case class ServiceStatus(
   runbook_url      : String // URI
 )
 object ServiceStatus {
-  implicit val dateTimeFormat = ??? // TODO
+  implicit val dateTimeFormat = new Format[DateTime] {
+    val isoFormatter = ISODateTimeFormat.dateTime()
+    def writes(o: DateTime): JsValue = Json toJson isoFormatter.print(o)
+    def reads(json: JsValue): JsResult[DateTime] = {
+      json.validate[String] map isoFormatter.parseDateTime
+    }
+  }
 
   implicit val durationFormat = new Format[JodaDuration] {
     def writes(o: JodaDuration): JsValue =

--- a/app/controllers/Se4Controller.scala
+++ b/app/controllers/Se4Controller.scala
@@ -1,7 +1,7 @@
 package controllers
 
 import org.joda.time.format.{ISODateTimeFormat, DateTimeFormat}
-import org.joda.time.{ DateTime, DateTimeZone, Duration => JodaDuration }
+import org.joda.time.{Duration => JodaDuration, Interval, DateTime, DateTimeZone}
 import play.api.libs.json.{ Format, JsResult, JsValue, Json }
 import play.api.mvc.{ Action, AnyContent, Controller }
 


### PR DESCRIPTION
Play serialises DateTime objects as integer milliseconds since epoch. We
prefer strings in ISO 8601 format.