### PR TITLE
Flesh out .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 /logs
+.idea/
+project/project/
+project/target/
+target/


### PR DESCRIPTION
Useful for those without epically set up global git ignore. May help
maintain repo hygiene in case of typy typy `commit -a`.